### PR TITLE
fix compilation issues on debian jessie 8.5 x64

### DIFF
--- a/xtea-cipher.h
+++ b/xtea-cipher.h
@@ -39,12 +39,12 @@ void xtea_decipher(const uint32_t *const v, uint32_t *const w,
     w[0]=y; w[1]=z;
 }
 
-inline void xtea_cbc_copy(unsigned char a[8], const unsigned char b[8]) {
+void xtea_cbc_copy(unsigned char a[8], const unsigned char b[8]) {
     ((uint32_t*)a)[0] = ((uint32_t*)b)[0];
     ((uint32_t*)a)[1] = ((uint32_t*)b)[1];
 }
 
-inline void xtea_cbc_xor(unsigned char a[8], const unsigned char b[8]) {
+void xtea_cbc_xor(unsigned char a[8], const unsigned char b[8]) {
     ((uint32_t*)a)[0] ^= ((uint32_t*)b)[0];
     ((uint32_t*)a)[1] ^= ((uint32_t*)b)[1];
 }


### PR DESCRIPTION
previous code resulted in:
xtea-cipher.h:74: undefined reference to `xtea_cbc_copy'
and refusal to compile.
This fixes it.
Maybe some minor performance loss...meh
